### PR TITLE
Remove compiler warnings

### DIFF
--- a/Inc/stm32l5xx_hal_def.h
+++ b/Inc/stm32l5xx_hal_def.h
@@ -58,7 +58,9 @@ typedef enum
 
 /* Exported macros -----------------------------------------------------------*/
 
+#ifndef UNUSED
 #define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#endif
 
 #define HAL_MAX_DELAY      0xFFFFFFFFU
 

--- a/Src/stm32l5xx_hal_cortex.c
+++ b/Src/stm32l5xx_hal_cortex.c
@@ -240,7 +240,7 @@ void HAL_NVIC_DisableIRQ(IRQn_Type IRQn)
   * @brief  Initiate a system reset request to reset the MCU.
   * @retval None
   */
-void HAL_NVIC_SystemReset(void)
+__attribute__((noreturn)) void HAL_NVIC_SystemReset(void)
 {
   /* System Reset */
   NVIC_SystemReset();

--- a/Src/stm32l5xx_hal_dma.c
+++ b/Src/stm32l5xx_hal_dma.c
@@ -919,6 +919,7 @@ HAL_StatusTypeDef HAL_DMA_RegisterCallback(DMA_HandleTypeDef *hdma, HAL_DMA_Call
            break;
 
      default:
+     case HAL_DMA_XFER_ALL_CB_ID:
            status = HAL_ERROR;
            break;
     }

--- a/Src/stm32l5xx_hal_pwr.c
+++ b/Src/stm32l5xx_hal_pwr.c
@@ -674,6 +674,8 @@ __weak void HAL_PWR_PVDCallback(void)
   */
 void HAL_PWR_ConfigAttributes(uint32_t Item, uint32_t Attributes)
 {
+  UNUSED(Item);
+   
   /* Check the parameters */
   assert_param(IS_PWR_ITEMS_ATTRIBUTES(Item));
   assert_param(IS_PWR_ATTRIBUTES(Attributes));
@@ -723,6 +725,8 @@ void HAL_PWR_ConfigAttributes(uint32_t Item, uint32_t Attributes)
 HAL_StatusTypeDef HAL_PWR_GetConfigAttributes(uint32_t Item, uint32_t *pAttributes)
 {
   uint32_t attributes;
+   
+  UNUSED(Item);
 
   /* Check null pointer */
   if (pAttributes == NULL)

--- a/Src/stm32l5xx_hal_rcc.c
+++ b/Src/stm32l5xx_hal_rcc.c
@@ -1375,6 +1375,9 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
 void HAL_RCC_MCOConfig(uint32_t RCC_MCOx, uint32_t RCC_MCOSource, uint32_t RCC_MCODiv)
 {
   GPIO_InitTypeDef GPIO_InitStruct;
+   
+  UNUSED(RCC_MCOx);
+   
   /* Check the parameters */
   assert_param(IS_RCC_MCO(RCC_MCOx));
   assert_param(IS_RCC_MCODIV(RCC_MCODiv));
@@ -1783,6 +1786,9 @@ __weak void HAL_RCC_CSSCallback(void)
   */
 void HAL_RCC_ConfigAttributes(uint32_t Item, uint32_t Attributes)
 {
+   
+  UNUSED(Item);
+   
   /* Check the parameters */
   assert_param(IS_RCC_ITEMS_ATTRIBUTES(Item));
   assert_param(IS_RCC_ATTRIBUTES(Attributes));
@@ -1831,6 +1837,8 @@ void HAL_RCC_ConfigAttributes(uint32_t Item, uint32_t Attributes)
 HAL_StatusTypeDef HAL_RCC_GetConfigAttributes(uint32_t Item, uint32_t *pAttributes)
 {
   uint32_t attributes;
+   
+  UNUSED(Item); 
 
   /* Check null pointer */
   if (pAttributes == NULL)

--- a/Src/stm32l5xx_hal_uart.c
+++ b/Src/stm32l5xx_hal_uart.c
@@ -3107,6 +3107,7 @@ HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
       case UART_CLOCKSOURCE_LSE:
         pclk = (uint32_t) LSE_VALUE;
         break;
+      case UART_CLOCKSOURCE_UNDEFINED:
       default:
         pclk = 0U;
         ret = HAL_ERROR;
@@ -3163,6 +3164,7 @@ HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
         pclk = (uint32_t) LSE_VALUE;
         break;
       default:
+      case UART_CLOCKSOURCE_UNDEFINED:
         pclk = 0U;
         ret = HAL_ERROR;
         break;
@@ -3204,6 +3206,7 @@ HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
         pclk = (uint32_t) LSE_VALUE;
         break;
       default:
+      case UART_CLOCKSOURCE_UNDEFINED:
         pclk = 0U;
         ret = HAL_ERROR;
         break;

--- a/Src/stm32l5xx_hal_usart.c
+++ b/Src/stm32l5xx_hal_usart.c
@@ -2953,6 +2953,7 @@ static HAL_StatusTypeDef USART_SetConfig(USART_HandleTypeDef *husart)
       usartdiv = (uint32_t)(USART_DIV_SAMPLING8(LSE_VALUE, husart->Init.BaudRate, husart->Init.ClockPrescaler));
       break;
     default:
+    case UART_CLOCKSOURCE_UNDEFINED:
       ret = HAL_ERROR;
       break;
   }


### PR DESCRIPTION
I did a support request via ST's support site but did not receive a satisfactory answer.

I compile using Keil v5.36.0.0 and the latest armclang v6 compiler.  When selecting the "All warning" compiler flag, there are multiple compiler warnings generated from within this HAL driver that obfuscate other compiler warnings.

This pull request does not include all of the fixes, but the very obvious ones.

I hope you would consider including this pull request.

Thank you.

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the CONTRIBUTING.md file.
